### PR TITLE
Prefer IPv4/6 command line flag

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -284,6 +284,11 @@ class WgetArgs(object):
             if concurrency is None:
                 concurrency = 4
         item['concurrency'] = str(concurrency)
+        
+        if '--prefer-ipv4' in sys.argv:
+            wget_args.extend(["--prefer-family", "IPv4"])
+        elif '--prefer-ipv6' in sys.argv:
+            wget_args.extend(["--prefer-family", "IPv6"])
 
         for item_name in item['item_name'].split('\0'):
             wget_args.extend(['--warc-header', 'x-wget-at-project-item-name: '+item_name])


### PR DESCRIPTION
Allow advanced users to optionally control if wget prefers ipv4 or ipv6 as it seems to default to ipv4 on dual-stack sites